### PR TITLE
Allow multiple sorts to work when sort order doesn't match config order

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ of the column this may not be the desired functionality. You can change this usi
 * `sort=priority:desc_nulls_first`
 
 
-You can set a default sort using the `setDefaultSort` on the`Sieve` class.
+You can set a default sort using the `setDefaultSort` on the`Sieve` class. The default sort uses the database column
+name rather than the mapped property name, meaning you can use the default sort property without having a map set up.
 
 ```php
 $sieve->setDefaultSort('name', 'asc')


### PR DESCRIPTION
This removes the sorting logic from the foreach loop, otherwise the order by queries are added in the order they are specified in the Sieve config rather than what the user provides.

I've clarified that default sort goes of column name rather than property name as this didn't previously work unless a sort config was given. The other way to fix this would be to go back to property name and enforce a config is given for Sieve.