### PR TITLE
Stop false string in URLs being detected as a truthy value

### DIFF
--- a/src/Filters/BooleanFilter.php
+++ b/src/Filters/BooleanFilter.php
@@ -24,7 +24,13 @@ class BooleanFilter implements ModifiesQueries
         if ($search->operator() == 'neq') {
             $op = '!=';
         }
-        $query->where($search->column(), $op, $search->term() == true ? $this->trueVal : $this->falseVal);
+
+        $searchTerm = true;
+        if ($search->term() == 'false') {
+            $searchTerm = false;
+        }
+
+        $query->where($search->column(), $op, $searchTerm ? $this->trueVal : $this->falseVal);
     }
 
     public function operators()

--- a/tests/Filters/BooleanFilterTest.php
+++ b/tests/Filters/BooleanFilterTest.php
@@ -16,7 +16,7 @@ class BooleanFilterTest extends TestCase
     {
         $filter = new BooleanFilter;
         $builder = Pet::query()->getQuery();
-        $filter->modifyQuery($builder, $this->searchTerm('eq', true));
+        $filter->modifyQuery($builder, $this->searchTerm('eq', 'true'));
 
         $this->assertEquals(
             "select * from `pets` where `is_active` = ?",
@@ -32,7 +32,7 @@ class BooleanFilterTest extends TestCase
     {
         $filter = new BooleanFilter;
         $builder = Pet::query()->getQuery();
-        $filter->modifyQuery($builder, $this->searchTerm('neq', true));
+        $filter->modifyQuery($builder, $this->searchTerm('neq', 'true'));
 
         $this->assertEquals(
             "select * from `pets` where `is_active` != ?",
@@ -46,16 +46,31 @@ class BooleanFilterTest extends TestCase
      */
     public function can_override_true_and_false_val()
     {
-
         $filter = new BooleanFilter('yes', 'no');
         $builder = Pet::query()->getQuery();
-        $filter->modifyQuery($builder, $this->searchTerm('eq', true));
+        $filter->modifyQuery($builder, $this->searchTerm('eq', 'true'));
 
         $this->assertEquals(
             "select * from `pets` where `is_active` = ?",
             $builder->toSql()
         );
         $this->assertEquals(['yes'], $builder->getBindings());
+    }
+
+    /**
+     * @test
+     */
+    public function can_handle_false_in_url_string_as_boolean()
+    {
+        $filter = new BooleanFilter;
+        $builder = Pet::query()->getQuery();
+        $filter->modifyQuery($builder, $this->searchTerm('eq', 'false'));
+
+        $this->assertEquals(
+            "select * from `pets` where `is_active` = ?",
+            $builder->toSql()
+        );
+        $this->assertEquals([0], $builder->getBindings());
     }
 
     private function searchTerm($operator, $term)


### PR DESCRIPTION
This fixes a bug where `false` in the URL is detected as `true` because it's not an empty string and so searching for `GET /v1/domains?auto_renew=false` would always return domains with auto renew on.