### PR TITLE
Make filters query modifiers generic

### DIFF
--- a/src/ModifiesQueries.php
+++ b/src/ModifiesQueries.php
@@ -3,13 +3,15 @@
 namespace UKFast\Sieve;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 interface ModifiesQueries
 {
     /**
      * Applies a search term to a query
-     * @param EloquentBuilder|QueryBuilder $query
+     * @template TModel of Model
+     * @param EloquentBuilder<TModel>|QueryBuilder $query
      * @return void
      */
     public function modifyQuery($query, SearchTerm $search);


### PR DESCRIPTION
Acombination of a Laravel update
(https://github.com/laravel/framework/commit/4529498671704a2ea4bae4af1e3f8ee48ca8dfd0) and a PHPStan update have led to new errors being thrown